### PR TITLE
Update game configs for Digimon Rumble Arena.

### DIFF
--- a/SLPS-03357/SLPS-03357.ini
+++ b/SLPS-03357/SLPS-03357.ini
@@ -10,3 +10,7 @@ PGXPEnable = false
 OverclockEnable = true
 OverclockNumerator = 5
 OverclockDenominator = 4
+
+
+[CDROM]
+ReadSpeedup = 2

--- a/SLUS-01404/SLUS-01404.ini
+++ b/SLUS-01404/SLUS-01404.ini
@@ -10,3 +10,7 @@ PGXPEnable = false
 OverclockEnable = true
 OverclockNumerator = 5
 OverclockDenominator = 4
+
+
+[CDROM]
+ReadSpeedup = 2

--- a/TRUE-OG212/TRUE-OG212.ini
+++ b/TRUE-OG212/TRUE-OG212.ini
@@ -15,4 +15,3 @@ OverclockDenominator = 4
 
 [CDROM]
 ReadSpeedup = 2
-SeekSpeedup = 0


### PR DESCRIPTION
Found out the seek speedup caused desync issues between the Windows build and Linux build of duckstation, so I'm removing it. Only shaved a few seconds of load anyways.

Also adding read speedup to the original versions, since that's been just fine for True OG for a long time, so no reason not to.